### PR TITLE
Fix error when no <directory> arg

### DIFF
--- a/pytest_watch/watcher.py
+++ b/pytest_watch/watcher.py
@@ -39,7 +39,7 @@ def watch(directory=None, auto_clear=False, extensions=[]):
     """Starts a server to render the specified file or directory containing a README."""
     if directory and not os.path.isdir(directory):
         raise ValueError('Directory not found: ' + directory)
-    directory = os.path.abspath(directory)
+    directory = os.path.abspath(directory or '')
 
     # Initial run
     event_handler = ChangeHandler(directory, auto_clear, extensions)


### PR DESCRIPTION
in case of `<directory>` is `None`, an error raises, as far as I tested