### PR TITLE
Add polling options for remote file systems

### DIFF
--- a/pytest_watch/command.py
+++ b/pytest_watch/command.py
@@ -15,6 +15,7 @@ Options:
   --onpass=<cmd>    Run arbitrary programs on pass.
   --onfail=<cmd>    Run arbitrary programs on failure.
   --nobeep          Do not beep on failure.
+  --poll            Use polling instead of events (useful in VMs)
   --ext=<exts>      Comma-separated list of file extensions that trigger a
                     new test run when changed (default: .py)
 """
@@ -41,4 +42,5 @@ def main(argv=None):
 
     extensions = args['--ext'].split(',') if args['--ext'] else []
     return watch(args['<directory>'], args['--clear'], not args['--nobeep'],
-                 args['--onpass'], args['--onfail'], extensions)
+                 args['--onpass'], args['--onfail'], args['--poll'],
+                 extensions)

--- a/pytest_watch/watcher.py
+++ b/pytest_watch/watcher.py
@@ -6,6 +6,7 @@ import subprocess
 
 from colorama import Fore
 from watchdog.observers import Observer
+from watchdog.observers.polling import PollingObserver
 from watchdog.events import FileSystemEventHandler
 
 
@@ -59,7 +60,7 @@ class ChangeHandler(FileSystemEventHandler):
 
 
 def watch(directory=None, auto_clear=False, beep_on_failure=True,
-          onpass=None, onfail=None, extensions=[]):
+          onpass=None, onfail=None, poll=False, extensions=[]):
     """
     Starts a server to render the specified file or directory
     containing a README.
@@ -74,7 +75,11 @@ def watch(directory=None, auto_clear=False, beep_on_failure=True,
     event_handler.run()
 
     # Setup watchdog
-    observer = Observer()
+    if poll:
+        observer = PollingObserver()
+    else:
+        observer = Observer()
+
     observer.schedule(event_handler, path=directory, recursive=True)
     observer.start()
 


### PR DESCRIPTION
This add the default polling observer if `--poll` is given to the command.  Something worth noting, is that even for one of my smallest projects there is a bit of a lag in startup time before it starts getting file changes, so when testing I had to wait a few seconds after the first test ran before it would register file changes. After that lag, it worked pretty well.

Closes #9 