### PR TITLE
Multiple directories support, norecursedirs, passing args to pytest

### DIFF
--- a/pytest_watch/command.py
+++ b/pytest_watch/command.py
@@ -52,7 +52,6 @@ def main(argv=None):
         '.' * (not ext.startswith('.')) + ext
         for ext in (args['--ext'] or '.py').split(',')
     ]
-    print(ignore, extensions)
 
     return watch(directories=directories,
                  ignore=ignore,

--- a/pytest_watch/command.py
+++ b/pytest_watch/command.py
@@ -4,20 +4,24 @@ pytest_watch.command
 
 Implements the command-line interface for pytest-watch.
 
+All positional arguments are passed directly to py.test executable.
+
 
 Usage:
-  ptw [options] [<directory>]
+  ptw [options] [--] [<args>...]
 
 Options:
   -h --help         Show this help.
   --version         Show version.
+  --watch=<dirs>    Command-separated list of directories to watch
+                    (default: current directory).
   -c --clear        Automatically clear the screen before each run.
-  --onpass=<cmd>    Run arbitrary programs on pass.
-  --onfail=<cmd>    Run arbitrary programs on failure.
+  --onpass=<cmd>    Run arbitrary command on pass.
+  --onfail=<cmd>    Run arbitrary command on failure.
   --nobeep          Do not beep on failure.
-  --poll            Use polling instead of events (useful in VMs)
+  -p --poll         Use polling instead of events (useful in VMs).
   --ext=<exts>      Comma-separated list of file extensions that trigger a
-                    new test run when changed (default: .py)
+                    new test run when changed (default: .py).
 """
 
 import sys
@@ -41,6 +45,13 @@ def main(argv=None):
     args = docopt(usage, argv=argv, version=version)
 
     extensions = args['--ext'].split(',') if args['--ext'] else []
-    return watch(args['<directory>'], args['--clear'], not args['--nobeep'],
-                 args['--onpass'], args['--onfail'], args['--poll'],
-                 extensions)
+    directories = args['--watch'].split(',') if args['--watch'] else []
+
+    return watch(directories=directories,
+                 auto_clear=args['--clear'],
+                 beep_on_failure=not args['--nobeep'],
+                 onpass=args['--onpass'],
+                 onfail=args['--onfail'],
+                 poll=args['--poll'],
+                 extensions=extensions,
+                 args=args['<args>'])

--- a/pytest_watch/command.py
+++ b/pytest_watch/command.py
@@ -8,7 +8,7 @@ All positional arguments after `--` are passed directly to py.test executable.
 
 
 Usage:
-  ptw [options] [<directories>...] [-- <args>...]
+  ptw [options] [-v | -q] [<directories>...] [-- <args>...]
 
 Options:
   -h --help         Show this help.
@@ -23,6 +23,8 @@ Options:
   --ext=<exts>      Comma-separated list of file extensions that trigger a
                     new test run when changed (default: .py).
   --no-spool        Disable event spooling (default: 200ms cooldown).
+  -v --verbose      Increase verbosity of the output.
+  -q --quiet        Decrease verbosity of the output.
 """
 
 import sys
@@ -63,4 +65,5 @@ def main(argv=None):
                  poll=args['--poll'],
                  extensions=extensions,
                  args=pytest_args,
-                 spool=not args['--no-spool'])
+                 spool=not args['--no-spool'],
+                 verbose=1 - bool(args['--quiet']) + bool(args['--verbose']))

--- a/pytest_watch/command.py
+++ b/pytest_watch/command.py
@@ -11,19 +11,19 @@ Usage:
   ptw [options] [--] [<args>...]
 
 Options:
-  -h --help               Show this help.
-  --version               Show version.
-  --watch=<dirs>          Command-separated list of directories to watch recursively
-                          (default: current directory).
-  --norecursedirs=<dirs>  Command-separated list of directories to not recurse to
-                          (if relative: starting from the root of each watched dir).
-  -c --clear              Automatically clear the screen before each run.
-  --onpass=<cmd>          Run arbitrary command on pass.
-  --onfail=<cmd>          Run arbitrary command on failure.
-  --nobeep                Do not beep on failure.
-  -p --poll               Use polling instead of events (useful in VMs).
-  --ext=<exts>            Comma-separated list of file extensions that trigger a
-                          new test run when changed (default: .py).
+  -h --help         Show this help.
+  --version         Show version.
+  --watch=<dirs>    Command-separated list of directories to be watched recursively
+                    (default: current directory).
+  --ignore=<dirs>   Command-separated list of directories to ignore when descending
+                    (if relative: starting from the root of each watched dir).
+  -c --clear        Automatically clear the screen before each run.
+  --onpass=<cmd>    Run arbitrary command on pass.
+  --onfail=<cmd>    Run arbitrary command on failure.
+  --nobeep          Do not beep on failure.
+  -p --poll         Use polling instead of events (useful in VMs).
+  --ext=<exts>      Comma-separated list of file extensions that trigger a
+                    new test run when changed (default: .py).
 """
 
 import sys
@@ -46,7 +46,7 @@ def main(argv=None):
 
     args = docopt(usage, argv=argv, version=version)
     return watch(directories=(args['--watch'] or '').split(','),
-                 norecursedirs=(args['--norecursedirs'] or '').split(','),
+                 ignore=(args['--ignore'] or '').split(','),
                  auto_clear=args['--clear'],
                  beep_on_failure=not args['--nobeep'],
                  onpass=args['--onpass'],

--- a/pytest_watch/command.py
+++ b/pytest_watch/command.py
@@ -4,7 +4,7 @@ pytest_watch.command
 
 Implements the command-line interface for pytest-watch.
 
-All positional arguments are passed directly to py.test executable.
+All positional arguments after `--` are passed directly to py.test executable.
 
 
 Usage:

--- a/pytest_watch/command.py
+++ b/pytest_watch/command.py
@@ -8,13 +8,11 @@ All positional arguments are passed directly to py.test executable.
 
 
 Usage:
-  ptw [options] [--] [<args>...]
+  ptw [options] [<directories>...] [-- <args>...]
 
 Options:
   -h --help         Show this help.
   --version         Show version.
-  --watch=<dirs>    Command-separated list of directories to be watched recursively
-                    (default: current directory).
   --ignore=<dirs>   Command-separated list of directories to ignore when descending
                     (if relative: starting from the root of each watched dir).
   -c --clear        Automatically clear the screen before each run.
@@ -39,18 +37,29 @@ def main(argv=None):
     """The entry point of the application."""
     colorama.init()
 
-    if argv is None:
-        argv = sys.argv[1:]
-    usage = '\n\n\n'.join(__doc__.split('\n\n\n')[1:])
+    usage = __doc__[__doc__.find('Usage:'):]
     version = 'pytest-watch ' + __version__
-
+    argv = argv if argv is not None else sys.argv[1:]
     args = docopt(usage, argv=argv, version=version)
-    return watch(directories=(args['--watch'] or '').split(','),
-                 ignore=(args['--ignore'] or '').split(','),
+
+    directories, pytest_args = args['<directories>'], []
+    if '--' in directories:
+        ix = directories.index('--')
+        directories, pytest_args = directories[:ix], directories[(ix + 1):]
+
+    ignore = (args['--ignore'] or '').split(',')
+    extensions = [
+        '.' * (not ext.startswith('.')) + ext
+        for ext in (args['--ext'] or '.py').split(',')
+    ]
+    print(ignore, extensions)
+
+    return watch(directories=directories,
+                 ignore=ignore,
                  auto_clear=args['--clear'],
                  beep_on_failure=not args['--nobeep'],
                  onpass=args['--onpass'],
                  onfail=args['--onfail'],
                  poll=args['--poll'],
-                 extensions=(args['--ext'] or '.py').split(','),
-                 args=args['<args>'])
+                 extensions=extensions,
+                 args=pytest_args)

--- a/pytest_watch/command.py
+++ b/pytest_watch/command.py
@@ -22,6 +22,7 @@ Options:
   -p --poll         Use polling instead of events (useful in VMs).
   --ext=<exts>      Comma-separated list of file extensions that trigger a
                     new test run when changed (default: .py).
+  --no-spool        Disable event spooling (default: 200ms cooldown).
 """
 
 import sys
@@ -61,4 +62,5 @@ def main(argv=None):
                  onfail=args['--onfail'],
                  poll=args['--poll'],
                  extensions=extensions,
-                 args=pytest_args)
+                 args=pytest_args,
+                 spool=not args['--no-spool'])

--- a/pytest_watch/command.py
+++ b/pytest_watch/command.py
@@ -11,17 +11,19 @@ Usage:
   ptw [options] [--] [<args>...]
 
 Options:
-  -h --help         Show this help.
-  --version         Show version.
-  --watch=<dirs>    Command-separated list of directories to watch
-                    (default: current directory).
-  -c --clear        Automatically clear the screen before each run.
-  --onpass=<cmd>    Run arbitrary command on pass.
-  --onfail=<cmd>    Run arbitrary command on failure.
-  --nobeep          Do not beep on failure.
-  -p --poll         Use polling instead of events (useful in VMs).
-  --ext=<exts>      Comma-separated list of file extensions that trigger a
-                    new test run when changed (default: .py).
+  -h --help               Show this help.
+  --version               Show version.
+  --watch=<dirs>          Command-separated list of directories to watch recursively
+                          (default: current directory).
+  --norecursedirs=<dirs>  Command-separated list of directories to not recurse to
+                          (if relative: starting from the root of each watched dir).
+  -c --clear              Automatically clear the screen before each run.
+  --onpass=<cmd>          Run arbitrary command on pass.
+  --onfail=<cmd>          Run arbitrary command on failure.
+  --nobeep                Do not beep on failure.
+  -p --poll               Use polling instead of events (useful in VMs).
+  --ext=<exts>            Comma-separated list of file extensions that trigger a
+                          new test run when changed (default: .py).
 """
 
 import sys
@@ -43,15 +45,12 @@ def main(argv=None):
     version = 'pytest-watch ' + __version__
 
     args = docopt(usage, argv=argv, version=version)
-
-    extensions = args['--ext'].split(',') if args['--ext'] else []
-    directories = args['--watch'].split(',') if args['--watch'] else []
-
-    return watch(directories=directories,
+    return watch(directories=(args['--watch'] or '').split(','),
+                 norecursedirs=(args['--norecursedirs'] or '').split(','),
                  auto_clear=args['--clear'],
                  beep_on_failure=not args['--nobeep'],
                  onpass=args['--onpass'],
                  onfail=args['--onfail'],
                  poll=args['--poll'],
-                 extensions=extensions,
+                 extensions=(args['--ext'] or '.py').split(','),
                  args=args['<args>'])

--- a/pytest_watch/spooler.py
+++ b/pytest_watch/spooler.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8
+
+from multiprocessing import Queue, Process, Event
+
+
+class Timer(Process):
+    def __init__(self, interval, function, args=[], kwargs={}):
+        super(Timer, self).__init__()
+        self.interval = interval
+        self.function = function
+        self.args = args
+        self.kwargs = kwargs
+        self.finished = Event()
+
+    def cancel(self):
+        self.finished.set()
+
+    def run(self):
+        self.finished.wait(self.interval)
+        if not self.finished.is_set():
+            self.function(*self.args, **self.kwargs)
+        self.finished.set()
+
+
+class EventSpooler(object):
+    def __init__(self, cooldown, callback):
+        self.cooldown = cooldown
+        self.callback = callback
+        self.inbox = Queue()
+        self.outbox = Queue()
+
+    def enqueue(self, event):
+        self.inbox.put(event)
+        Timer(self.cooldown, self.process).start()
+
+    def process(self):
+        self.outbox.put(self.inbox.get())
+        if self.inbox.empty():
+            self.callback([self.outbox.get() for _ in range(self.outbox.qsize())])

--- a/pytest_watch/spooler.py
+++ b/pytest_watch/spooler.py
@@ -36,4 +36,7 @@ class EventSpooler(object):
     def process(self):
         self.outbox.put(self.inbox.get())
         if self.inbox.empty():
-            self.callback([self.outbox.get() for _ in range(self.outbox.qsize())])
+            events = []
+            while not self.outbox.empty():
+                events.append(self.outbox.get())
+            self.callback(events)

--- a/pytest_watch/watcher.py
+++ b/pytest_watch/watcher.py
@@ -81,12 +81,12 @@ def watch(directory=None, auto_clear=False, beep_on_failure=True,
         observer = Observer()
 
     observer.schedule(event_handler, path=directory, recursive=True)
-    observer.start()
 
     # Watch and run tests until interrupted by user
     try:
+        observer.start()
         while True:
             time.sleep(1)
+        observer.join()
     except KeyboardInterrupt:
         observer.stop()
-    observer.join()

--- a/pytest_watch/watcher.py
+++ b/pytest_watch/watcher.py
@@ -46,7 +46,6 @@ class ChangeHandler(FileSystemEventHandler):
         print(Fore.CYAN + msg.format(Fore.LIGHTCYAN_EX + arg + Fore.CYAN) + Fore.RESET)
         if self.auto_clear:
             print()
-        command = ' '.join(['py.test'] + self.args)
         exit_code = subprocess.call(command, shell=True)
         passed = exit_code == 0
 

--- a/pytest_watch/watcher.py
+++ b/pytest_watch/watcher.py
@@ -61,10 +61,6 @@ class ChangeHandler(FileSystemEventHandler):
 
 def watch(directory=None, auto_clear=False, beep_on_failure=True,
           onpass=None, onfail=None, poll=False, extensions=[]):
-    """
-    Starts a server to render the specified file or directory
-    containing a README.
-    """
     if directory and not os.path.isdir(directory):
         raise ValueError('Directory not found: ' + directory)
     directory = os.path.abspath(directory or '')

--- a/pytest_watch/watcher.py
+++ b/pytest_watch/watcher.py
@@ -46,7 +46,7 @@ class ChangeHandler(FileSystemEventHandler):
         print(Fore.CYAN + msg.format(Fore.LIGHTCYAN_EX + arg + Fore.CYAN) + Fore.RESET)
         if self.auto_clear:
             print()
-        exit_code = subprocess.call(command, shell=True)
+        exit_code = subprocess.call(['py.test'] + self.args, shell=False)
         passed = exit_code == 0
 
         # Beep if failed

--- a/pytest_watch/watcher.py
+++ b/pytest_watch/watcher.py
@@ -38,11 +38,12 @@ class ChangeHandler(FileSystemEventHandler):
         """Called when a file is changed to re-run the tests with py.test."""
         if self.auto_clear:
             subprocess.call(CLEAR_COMMAND, shell=True)
-        elif filename:
-            print()
-            print(Fore.CYAN + 'Change detected in ' + filename + Fore.RESET)
+        command = ' '.join(['py.test'] + self.args)
+        msg, arg = 'Running pytest command: {}', command
+        if filename:
+            msg, arg = 'Change detected in {}, rerunning pytest command...', filename
         print()
-        print('Running unit tests...')
+        print(Fore.CYAN + msg.format(Fore.LIGHTCYAN_EX + arg + Fore.CYAN) + Fore.RESET)
         if self.auto_clear:
             print()
         command = ' '.join(['py.test'] + self.args)

--- a/pytest_watch/watcher.py
+++ b/pytest_watch/watcher.py
@@ -7,10 +7,11 @@ import subprocess
 from colorama import Fore
 from watchdog.observers import Observer
 from watchdog.observers.polling import PollingObserver
-from watchdog.events import FileSystemEventHandler, FileModifiedEvent, FileCreatedEvent
+from watchdog.events import (FileSystemEventHandler, FileModifiedEvent,
+                             FileCreatedEvent, FileMovedEvent)
 
 
-WATCHED_EVENTS = [FileModifiedEvent, FileCreatedEvent]
+WATCHED_EVENTS = [FileModifiedEvent, FileCreatedEvent, FileMovedEvent]
 DEFAULT_EXTENSIONS = ['.py']
 CLEAR_COMMAND = 'cls' if os.name == 'nt' else 'clear'
 BEEP_CHARACTER = '\a'
@@ -30,9 +31,10 @@ class ChangeHandler(FileSystemEventHandler):
 
     def on_any_event(self, event):
         if isinstance(event, tuple(WATCHED_EVENTS)):
-            ext = os.path.splitext(event.src_path)[1].lower()
+            dest = event.dest_path if isinstance(event, FileMovedEvent) else event.src_path
+            ext = os.path.splitext(dest)[1].lower()
             if ext in self.extensions:
-                self.run(event.src_path)
+                self.run(dest)
 
     def run(self, filename=None):
         """Called when a file is changed to re-run the tests with py.test."""

--- a/pytest_watch/watcher.py
+++ b/pytest_watch/watcher.py
@@ -6,7 +6,7 @@ import subprocess
 
 from .spooler import EventSpooler
 
-from colorama import Fore
+from colorama import Fore, Style
 from watchdog.observers import Observer
 from watchdog.observers.polling import PollingObserver
 from watchdog.events import (FileSystemEventHandler, FileModifiedEvent,
@@ -23,6 +23,8 @@ WATCHED_EVENTS = list(EVENT_NAMES)
 DEFAULT_EXTENSIONS = ['.py']
 CLEAR_COMMAND = 'cls' if os.name == 'nt' else 'clear'
 BEEP_CHARACTER = '\a'
+STYLE_NORMAL = Fore.WHITE + Style.NORMAL + Style.DIM
+STYLE_HIGHLIGHT = Fore.CYAN + Style.NORMAL + Style.BRIGHT
 
 
 class ChangeHandler(FileSystemEventHandler):
@@ -60,7 +62,7 @@ class ChangeHandler(FileSystemEventHandler):
         if self.auto_clear:
             subprocess.call(CLEAR_COMMAND)
         command = ' '.join(['py.test'] + self.args)
-        highlight = lambda arg: Fore.LIGHTWHITE_EX + arg + Fore.CYAN
+        highlight = lambda arg: STYLE_HIGHLIGHT + arg + STYLE_NORMAL
         msg = 'Running pytest command: {}'.format(highlight(command))
         if summary:
             msg = 'Changes detected in files:\n{}\n\nRerunning pytest command: {}'.format(
@@ -69,8 +71,8 @@ class ChangeHandler(FileSystemEventHandler):
                           for event_name, paths in summary),
                 highlight(command)
             )
-        print()
-        print(Fore.CYAN + msg + Fore.RESET)
+            print()
+        print(STYLE_NORMAL + msg + Fore.RESET + Style.NORMAL)
         if self.auto_clear:
             print()
         exit_code = subprocess.call(['py.test'] + self.args)

--- a/pytest_watch/watcher.py
+++ b/pytest_watch/watcher.py
@@ -7,9 +7,10 @@ import subprocess
 from colorama import Fore
 from watchdog.observers import Observer
 from watchdog.observers.polling import PollingObserver
-from watchdog.events import FileSystemEventHandler
+from watchdog.events import FileSystemEventHandler, FileModifiedEvent, FileCreatedEvent
 
 
+WATCHED_EVENTS = [FileModifiedEvent, FileCreatedEvent]
 DEFAULT_EXTENSIONS = ['.py']
 CLEAR_COMMAND = 'cls' if os.name == 'nt' else 'clear'
 BEEP_CHARACTER = '\a'
@@ -28,11 +29,10 @@ class ChangeHandler(FileSystemEventHandler):
         self.extensions = extensions or DEFAULT_EXTENSIONS
 
     def on_any_event(self, event):
-        if event.is_directory:
-            return
-        ext = os.path.splitext(event.src_path)[1].lower()
-        if ext in self.extensions:
-            self.run(event.src_path)
+        if isinstance(event, tuple(WATCHED_EVENTS)):
+            ext = os.path.splitext(event.src_path)[1].lower()
+            if ext in self.extensions:
+                self.run(event.src_path)
 
     def run(self, filename=None):
         """Called when a file is changed to re-run the tests with nose."""

--- a/pytest_watch/watcher.py
+++ b/pytest_watch/watcher.py
@@ -62,7 +62,7 @@ class ChangeHandler(FileSystemEventHandler):
             os.system(self.onfail)
 
 
-def watch(directories=[], norecursedirs=[], auto_clear=False, beep_on_failure=True,
+def watch(directories=[], ignore=[], auto_clear=False, beep_on_failure=True,
           onpass=None, onfail=None, poll=False, extensions=[], args=[]):
     if not directories:
         directories = ['.']
@@ -72,7 +72,7 @@ def watch(directories=[], norecursedirs=[], auto_clear=False, beep_on_failure=Tr
             raise ValueError('Directory not found: ' + directory)
     recursive_dirs = directories
     non_recursive_dirs = []
-    if norecursedirs:
+    if ignore:
         non_recursive_dirs = []
         recursive_dirs = []
         for directory in directories:
@@ -83,8 +83,8 @@ def watch(directories=[], norecursedirs=[], auto_clear=False, beep_on_failure=Tr
             ]
             ok_subdirs = [
                 subd for subd in subdirs
-                if not any(os.path.samefile(os.path.join(directory, nrd), subd)
-                           for nrd in norecursedirs)
+                if not any(os.path.samefile(os.path.join(directory, d), subd)
+                           for d in ignore)
             ]
             if len(subdirs) == len(ok_subdirs):
                 recursive_dirs.append(directory)

--- a/pytest_watch/watcher.py
+++ b/pytest_watch/watcher.py
@@ -39,7 +39,7 @@ class ChangeHandler(FileSystemEventHandler):
     def run(self, filename=None):
         """Called when a file is changed to re-run the tests with py.test."""
         if self.auto_clear:
-            subprocess.call(CLEAR_COMMAND, shell=True)
+            subprocess.call(CLEAR_COMMAND)
         command = ' '.join(['py.test'] + self.args)
         msg, arg = 'Running pytest command: {}', command
         if filename:
@@ -48,7 +48,7 @@ class ChangeHandler(FileSystemEventHandler):
         print(Fore.CYAN + msg.format(Fore.LIGHTCYAN_EX + arg + Fore.CYAN) + Fore.RESET)
         if self.auto_clear:
             print()
-        exit_code = subprocess.call(['py.test'] + self.args, shell=False)
+        exit_code = subprocess.call(['py.test'] + self.args)
         passed = exit_code == 0
 
         # Beep if failed


### PR DESCRIPTION
I believe this PR closes all outstanding issues (#5, #6, #7 and #8). If merged in, this probably calls for a version bump.

The README will probably need to be updated as well..

Options added / things modified:
- All positional arguments after `--` are now passed as is to `py.test` executable.
- Added support for multiple watched folders (passed as positional arguments).
- Allow to ignore sub folders (currently via an exact match only at a first level of each watched folder, but this could be improved quite easily to support arbitrary patterns). Note that this is done at the observer level and not in the event handler because if you have tens of thousands of files in a subfolder like `.tox` for example, the handler would get completely swamped by that (so a simple pattern matching inside `on_any_event` is not going to cut it).
- py.test subprocess no longer changes directory to a watched folder -- this no longer makes any sense given that any args can be passed to pytest and you can watch multiple folders at once.
- py.test subprocess no longer runs with shell=True, to handle quoted arguments properly.
- Catch `KeyboardInterrupt` even if it was caught after the first test run and exit gracefully.
- Instead of catching all file events, only react to `FileModifiedEvent` and `FileCreatedEvent`. This fixed the problem where duplicate watchdog events would be fired upon a single file modification if using remote NFS mounts on Linux.
- Added `-p` alias to `--poll`.
- The exact py.test command is now printed to stdout upon the first test run.
- Added event spooling with 200ms cooldown to work around atomic saves in different editors.
- Added `--verbose` / `--quiet` options.
- Added `--no-spool` option to disable spooling.
- `--ext` option will prepend extensions with periods if needed.

An example using the new functionality:
```sh
ptw -v -p --no-spool --ignore=.tox,.git folder1 folder2 -- tests/*.py -svv
```