### PR TITLE
Fix wrong subprocess call

### DIFF
--- a/pytest_watch/watcher.py
+++ b/pytest_watch/watcher.py
@@ -88,7 +88,7 @@ class ChangeHandler(FileSystemEventHandler):
                     msg = ('Changes detected, rerunning: {}'
                            .format(highlight(command)))
             print(STYLE_NORMAL + msg + Fore.RESET + Style.NORMAL)
-        exit_code = subprocess.call(['py.test'] + self.args, shell=True)
+        exit_code = subprocess.call(command, shell=True)
         passed = exit_code == 0
 
         # Beep if failed


### PR DESCRIPTION
As you know, `subprocess.call` has some specific requirements on `shell` and the type of `args`.

 - https://docs.python.org/2/library/subprocess.html#frequently-used-arguments

On my windows machine with MINGW32:
```
>>> import subprocess
>>> subprocess.call(['ls', '-l'], shell=False)
total 0
-rw-r--r--  1 grampush  Administ  0  6 24 01:15 a.out
-rw-r--r--  1 grampush  Administ  0  6 24 01:14 sample.wav
-rw-r--r--  1 grampush  Administ  0  6 24 01:15 zigbee.bin
0
>>> subprocess.call(['ls', '-l'], shell=True)
-rw-r--r--  1 grampush  Administ  0  6 24 01:15 a.out
-rw-r--r--  1 grampush  Administ  0  6 24 01:14 sample.wav
-rw-r--r--  1 grampush  Administ  0  6 24 01:15 zigbee.bin
0
>>> 
```

However, on OS X:
```
>>> import subprocess
>>> subprocess.call(['ls', '-l'], shell=False)
total 0
-rw-r--r--  1 grampush  staff  0  6 24 01:15 a.out
-rw-r--r--  1 grampush  staff  0  6 24 01:14 sample.wav
-rw-r--r--  1 grampush  staff  0  6 24 01:15 zigbee.bin
0
>>> subprocess.call(['ls', '-l'], shell=True)
a.out		sample.wav	zigbee.bin
0
>>> 
```
Only the first item of `args` is applied to the actual execution, in this case.

I think we should do: `call(a_list, shell=False)` or `call(a_str, shell=True)`