### PR TITLE
Fix passing args to py.test on POSIX systems

### DIFF
--- a/pytest_watch/watcher.py
+++ b/pytest_watch/watcher.py
@@ -88,7 +88,8 @@ class ChangeHandler(FileSystemEventHandler):
                     msg = ('Changes detected, rerunning: {}'
                            .format(highlight(command)))
             print(STYLE_NORMAL + msg + Fore.RESET + Style.NORMAL)
-        exit_code = subprocess.call(['py.test'] + self.args, shell=True)
+        exit_code = subprocess.call(['py.test'] + self.args,
+                                    shell=subprocess.mswindows)
         passed = exit_code == 0
 
         # Beep if failed


### PR DESCRIPTION
Use shell=True only for MS Windows when executing py.test.

Ref: https://github.com/aldanor/pytest-watch/commit/dc066e212#commitcomment-11887976