### PR TITLE
Use the default fg for STYLE_NORMAL

### DIFF
--- a/pytest_watch/watcher.py
+++ b/pytest_watch/watcher.py
@@ -24,7 +24,7 @@ WATCHED_EVENTS = list(EVENT_NAMES)
 DEFAULT_EXTENSIONS = ['.py']
 CLEAR_COMMAND = 'cls' if os.name == 'nt' else 'clear'
 BEEP_CHARACTER = '\a'
-STYLE_NORMAL = Fore.WHITE + Style.NORMAL + Style.DIM
+STYLE_NORMAL = Fore.RESET
 STYLE_HIGHLIGHT = Fore.CYAN + Style.NORMAL + Style.BRIGHT
 
 


### PR DESCRIPTION
Using "white" explicitly causes problems on terminals with a light
background (e.g. Solarized White): just use the default fg.

I've not changed STYLE_HIGHLIGHT, but there `Fore.RESET + Style.BRIGHT`
might be better, too.