### PR TITLE
Python 3.5.0 compatibility

### DIFF
--- a/pytest_watch/watcher.py
+++ b/pytest_watch/watcher.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import os
 import time
 import subprocess
+import sys
 
 from colorama import Fore, Style
 from watchdog.events import (
@@ -92,7 +93,7 @@ class ChangeHandler(FileSystemEventHandler):
         if self.beforerun:
             os.system(self.beforerun)
         exit_code = subprocess.call(['py.test'] + self.args,
-                                    shell=subprocess.mswindows)
+                                    shell=(sys.platform == 'win32'))
         passed = exit_code == 0
 
         # Beep if failed


### PR DESCRIPTION
In Python 3.5.0, subprocess.mswindows is renamed to subprocess._mswindows.

Fixes the following error:

```
Traceback (most recent call last):
  File "/Users/coltonprovias/Development/MyNewLeaf/bin/ptw", line 11, in <module>
    sys.exit(main())
  File "/Users/coltonprovias/Development/MyNewLeaf/lib/python3.5/site-packages/pytest_watch/command.py", line 74, in main
    quiet=args['--quiet'])
  File "/Users/coltonprovias/Development/MyNewLeaf/lib/python3.5/site-packages/pytest_watch/watcher.py", line 130, in watch
    event_handler.run()
  File "/Users/coltonprovias/Development/MyNewLeaf/lib/python3.5/site-packages/pytest_watch/watcher.py", line 95, in run
    shell=subprocess.mswindows)
AttributeError: module 'subprocess' has no attribute 'mswindows'
```