### PR TITLE
Fix beep: flush the output buffer

### DIFF
--- a/pytest_watch/watcher.py
+++ b/pytest_watch/watcher.py
@@ -98,7 +98,8 @@ class ChangeHandler(FileSystemEventHandler):
 
         # Beep if failed
         if not passed and self.beep_on_failure:
-            print(BEEP_CHARACTER, end='')
+            sys.stdout.write(BEEP_CHARACTER)
+            sys.stdout.flush()
 
         # Run custom commands
         if passed and self.onpass:


### PR DESCRIPTION
It works when using it through `--onfail 'python -c "print(\"\a\",
end=\"\")";'`, but not with the default options (without `--nobeep`).

I am not sure why that is required?!

I am using Python 3.5.0.