### PR TITLE
Add --onexit option

### DIFF
--- a/pytest_watch/command.py
+++ b/pytest_watch/command.py
@@ -19,6 +19,7 @@ Options:
   --beforerun=<cmd> Run arbitrary command before tests are run.
   --onpass=<cmd>    Run arbitrary command on pass.
   --onfail=<cmd>    Run arbitrary command on failure.
+  --onexit=<cmd>    Run arbitrary command when exiting.
   --nobeep          Do not beep on failure.
   -p --poll         Use polling instead of events (useful in VMs).
   --ext=<exts>      Comma-separated list of file extensions that trigger a
@@ -66,6 +67,7 @@ def main(argv=None):
                  onpass=args['--onpass'],
                  onfail=args['--onfail'],
                  beforerun=args['--beforerun'],
+                 onexit=args['--onexit'],
                  poll=args['--poll'],
                  extensions=extensions,
                  args=pytest_args,

--- a/pytest_watch/watcher.py
+++ b/pytest_watch/watcher.py
@@ -108,8 +108,8 @@ class ChangeHandler(FileSystemEventHandler):
 
 
 def watch(directories=[], ignore=[], auto_clear=False, beep_on_failure=True,
-          onpass=None, onfail=None, beforerun=None, poll=False, extensions=[],
-          args=[], spool=True, verbose=False, quiet=False):
+          onpass=None, onfail=None, beforerun=None, onexit=None, poll=False,
+          extensions=[], args=[], spool=True, verbose=False, quiet=False):
     if not directories:
         directories = ['.']
     directories = [os.path.abspath(directory) for directory in directories]
@@ -145,6 +145,8 @@ def watch(directories=[], ignore=[], auto_clear=False, beep_on_failure=True,
         observer.join()
     except KeyboardInterrupt:
         observer.stop()
+    if onexit:
+        os.system(onexit)
 
 
 def samepath(left, right):


### PR DESCRIPTION
This is useful in a Makefile, where Ctrl-C will not execute later
commands, and you want to restore settings from onfail, onpass etc.