### PR TITLE
Added loading options from pytest.ini

### DIFF
--- a/pytest_watch/command.py
+++ b/pytest_watch/command.py
@@ -103,6 +103,8 @@ def main(argv=None):
     args = {}
     for arg_key in args_cmd:
         args[arg_key] = args_cmd[arg_key] or args_ini.get(arg_key)
+    if args["--verbose"]:
+        print("pytest-watch args: " + str(args))
 
     pytest_args = []
     directories = args['<directories>']

--- a/pytest_watch/command.py
+++ b/pytest_watch/command.py
@@ -60,90 +60,45 @@ def main(argv=None):
     pytest_ini_path = get_pytest_ini_path()
     config_ini.read(pytest_ini_path)
     args_ini = {}
-    if config_ini.has_section("pytest-watch"):
-        # string config values
-        if config_ini.has_option("pytest-watch", "onpass"):
-            args_ini['--onpass'] = config_ini.get("pytest-watch", "onpass")
-        else:
-            args_ini['--onpass'] = None
 
-        if config_ini.has_option("pytest-watch", "onfail"):
-            args_ini['--onfail'] = config_ini.get("pytest-watch", "onfail")
-        else:
-            args_ini['--onfail'] = None
+    # string ini config values
+    args_ini["--onpass"] = get_ini_option(config_ini, "onpass")
 
-        if config_ini.has_option("pytest-watch", "beforerun"):
-            args_ini['--beforerun'] = config_ini.get("pytest-watch", "beforerun")
-        else:
-            args_ini['--beforerun'] = None
+    args_ini["--onfail"] = get_ini_option(config_ini, "onfail")
 
-        if config_ini.has_option("pytest-watch", "onexit"):
-            args_ini['--onexit'] = config_ini.get("pytest-watch", "onexit")
-        else:
-            args_ini['--onexit'] = None
+    args_ini["--beforerun"] = get_ini_option(config_ini, "beforerun")
 
-        if config_ini.has_option("pytest-watch", "ext"):
-            args_ini['--ext'] = config_ini.get("pytest-watch", "ext")
-        else:
-            args_ini['--ext'] = None
+    args_ini["--onexit"] = get_ini_option(config_ini, "onexit")
 
-        if config_ini.has_option("pytest-watch", "ignore"):
-            args_ini['--ignore'] = config_ini.get("pytest-watch", "ignore")
-        else:
-            args_ini['--ignore'] = None
+    args_ini["--ext"] = get_ini_option(config_ini, "ext")
 
-        # boolean config values
-        if config_ini.has_option("pytest-watch", "help"):
-            args_ini["--help"] = config_ini.getboolean("pytest-watch", "help")
-        else:
-            args_ini["--help"] = False
+    args_ini["--ignore"] = get_ini_option(config_ini, "ignore")
 
-        if config_ini.has_option("pytest-watch", "version"):
-            args_ini["--version"] = config_ini.getboolean("pytest-watch", "version")
-        else:
-            args_ini["--version"] = False
+    # boolean ini config values
+    args_ini["--help"] = get_ini_option_boolean(config_ini, "help")
 
-        if config_ini.has_option("pytest-watch", "clear"):
-            args_ini["--clear"] = config_ini.getboolean("pytest-watch", "clear")
-        else:
-            args_ini["--clear"] = False
+    args_ini["--version"] = get_ini_option_boolean(config_ini, "version")
 
-        if config_ini.has_option("pytest-watch", "nobeep"):
-            args_ini["--nobeep"] = config_ini.getboolean("pytest-watch", "nobeep")
-        else:
-            args_ini["--nobeep"] = False
+    args_ini["--clear"] = get_ini_option_boolean(config_ini, "clear")
 
-        if config_ini.has_option("pytest-watch", "poll"):
-            args_ini["--poll"] = config_ini.getboolean("pytest-watch", "poll")
-        else:
-            args_ini["--poll"] = False
+    args_ini["--nobeep"] = get_ini_option_boolean(config_ini, "nobeep")
 
-        if config_ini.has_option("pytest-watch", "no-spool"):
-            args_ini["--no-spool"] = config_ini.getboolean("pytest-watch", "no-spool")
-        else:
-            args_ini["--no-spool"] = False
+    args_ini["--poll"] = get_ini_option_boolean(config_ini, "poll")
 
-        if config_ini.has_option("pytest-watch", "verbose"):
-            args_ini["--verbose"] = config_ini.getboolean("pytest-watch", "verbose")
-        else:
-            args_ini["--verbose"] = False
+    args_ini["--no-spool"] = get_ini_option_boolean(config_ini, "no-spool")
 
-        if config_ini.has_option("pytest-watch", "quiet"):
-            args_ini["--quiet"] = config_ini.getboolean("pytest-watch", "quiet")
-        else:
-            args_ini["--quiet"] = False
+    args_ini["--verbose"] = get_ini_option_boolean(config_ini, "verbose")
 
-        # other config values
-        if config_ini.has_option("pytest-watch", "directories"):
-            args_ini['<directories>'] = config_ini.get("pytest-watch", "directories")
-            args_ini['<directories>'] = args_ini['<directories>'].split(", ")
-        else:
-            args_ini['<directories>'] = []
+    args_ini["--quiet"] = get_ini_option_boolean(config_ini, "quiet")
 
-        if config_ini.has_option("pytest-watch", "addopts"):
-            args_ini["<args>"] = config_ini.get("pytest-watch", "addopts")
-        else:
-            args_ini["<args>"] = None
+    # other config values
+    if config_ini.has_option("pytest-watch", "directories"):
+        args_ini['<directories>'] = config_ini.get("pytest-watch", "directories")
+        args_ini['<directories>'] = args_ini['<directories>'].split(", ")
+    else:
+        args_ini['<directories>'] = []
+
+    args_ini["<args>"] = get_ini_option(config_ini, "addopts")
 
     args = {}
     for arg_key in args_cmd:
@@ -193,3 +148,17 @@ def get_pytest_ini_path():
 
     pytest.main("--collect-only", plugins=[CollectIniPathPlugin()])
     return(CollectorIniPath.pytest_ini_path)
+
+
+def get_ini_option(config_parser, option_name):
+    if config_parser.has_option("pytest-watch", option_name):
+        return config_parser.get("pytest-watch", option_name)
+    else:
+        return None
+
+
+def get_ini_option_boolean(config_parser, option_name):
+    if config_parser.has_option("pytest-watch", option_name):
+        return config_parser.getboolean("pytest-watch", option_name)
+    else:
+        return False

--- a/pytest_watch/command.py
+++ b/pytest_watch/command.py
@@ -38,7 +38,7 @@ from docopt import docopt
 from .watcher import watch
 from . import __version__
 
-import pytest
+from ini_config_helpers import get_ini_option, get_ini_option_boolean, get_pytest_ini_path
 
 try:
     from configparser import ConfigParser

--- a/pytest_watch/command.py
+++ b/pytest_watch/command.py
@@ -137,7 +137,7 @@ def main(argv=None):
 class CollectIniPathPlugin(object):
 
     def pytest_cmdline_main(self, config):
-        CollectorIniPath.pytest_ini_path = str(config.inifile.realpath())
+        CollectorIniPath.pytest_ini_path = config.inifile.realpath().strpath
 
 
 class CollectorIniPath(object):

--- a/pytest_watch/command.py
+++ b/pytest_watch/command.py
@@ -37,6 +37,13 @@ from docopt import docopt
 from .watcher import watch
 from . import __version__
 
+import pytest
+
+try:
+    from configparser import ConfigParser
+except ImportError:
+    from ConfigParser import ConfigParser  # ver. < 3.0
+
 
 def main(argv=None):
     """
@@ -47,7 +54,100 @@ def main(argv=None):
     usage = __doc__[__doc__.find('Usage:'):]
     version = 'pytest-watch ' + __version__
     argv = argv if argv is not None else sys.argv[1:]
-    args = docopt(usage, argv=argv, version=version)
+    args_cmd = docopt(usage, argv=argv, version=version)
+
+    config_ini = ConfigParser()
+    pytest_ini_path = get_pytest_ini_path()
+    config_ini.read(pytest_ini_path)
+    args_ini = {}
+    if config_ini.has_section("pytest-watch"):
+        # string config values
+        if config_ini.has_option("pytest-watch", "onpass"):
+            args_ini['--onpass'] = config_ini.get("pytest-watch", "onpass")
+        else:
+            args_ini['--onpass'] = None
+
+        if config_ini.has_option("pytest-watch", "onfail"):
+            args_ini['--onfail'] = config_ini.get("pytest-watch", "onfail")
+        else:
+            args_ini['--onfail'] = None
+
+        if config_ini.has_option("pytest-watch", "beforerun"):
+            args_ini['--beforerun'] = config_ini.get("pytest-watch", "beforerun")
+        else:
+            args_ini['--beforerun'] = None
+
+        if config_ini.has_option("pytest-watch", "onexit"):
+            args_ini['--onexit'] = config_ini.get("pytest-watch", "onexit")
+        else:
+            args_ini['--onexit'] = None
+
+        if config_ini.has_option("pytest-watch", "ext"):
+            args_ini['--ext'] = config_ini.get("pytest-watch", "ext")
+        else:
+            args_ini['--ext'] = None
+
+        if config_ini.has_option("pytest-watch", "ignore"):
+            args_ini['--ignore'] = config_ini.get("pytest-watch", "ignore")
+        else:
+            args_ini['--ignore'] = None
+
+        # boolean config values
+        if config_ini.has_option("pytest-watch", "help"):
+            args_ini["--help"] = config_ini.getboolean("pytest-watch", "help")
+        else:
+            args_ini["--help"] = False
+
+        if config_ini.has_option("pytest-watch", "version"):
+            args_ini["--version"] = config_ini.getboolean("pytest-watch", "version")
+        else:
+            args_ini["--version"] = False
+
+        if config_ini.has_option("pytest-watch", "clear"):
+            args_ini["--clear"] = config_ini.getboolean("pytest-watch", "clear")
+        else:
+            args_ini["--clear"] = False
+
+        if config_ini.has_option("pytest-watch", "nobeep"):
+            args_ini["--nobeep"] = config_ini.getboolean("pytest-watch", "nobeep")
+        else:
+            args_ini["--nobeep"] = False
+
+        if config_ini.has_option("pytest-watch", "poll"):
+            args_ini["--poll"] = config_ini.getboolean("pytest-watch", "poll")
+        else:
+            args_ini["--poll"] = False
+
+        if config_ini.has_option("pytest-watch", "no-spool"):
+            args_ini["--no-spool"] = config_ini.getboolean("pytest-watch", "no-spool")
+        else:
+            args_ini["--no-spool"] = False
+
+        if config_ini.has_option("pytest-watch", "verbose"):
+            args_ini["--verbose"] = config_ini.getboolean("pytest-watch", "verbose")
+        else:
+            args_ini["--verbose"] = False
+
+        if config_ini.has_option("pytest-watch", "quiet"):
+            args_ini["--quiet"] = config_ini.getboolean("pytest-watch", "quiet")
+        else:
+            args_ini["--quiet"] = False
+
+        # other config values
+        if config_ini.has_option("pytest-watch", "directories"):
+            args_ini['<directories>'] = config_ini.get("pytest-watch", "directories")
+            args_ini['<directories>'] = args_ini['<directories>'].split(", ")
+        else:
+            args_ini['<directories>'] = []
+
+        if config_ini.has_option("pytest-watch", "addopts"):
+            args_ini["<args>"] = config_ini.get("pytest-watch", "addopts")
+        else:
+            args_ini["<args>"] = None
+
+    args = {}
+    for arg_key in args_cmd:
+        args[arg_key] = args_cmd[arg_key] or args_ini.get(arg_key)
 
     pytest_args = []
     directories = args['<directories>']
@@ -73,3 +173,23 @@ def main(argv=None):
                  spool=not args['--no-spool'],
                  verbose=args['--verbose'],
                  quiet=args['--quiet'])
+
+# For collecting path of the ini
+
+
+class CollectIniPathPlugin(object):
+
+    def pytest_cmdline_main(self, config):
+        CollectorIniPath.pytest_ini_path = str(config.inifile.realpath())
+
+
+class CollectorIniPath(object):
+
+    """ Object for storing the path from CollectIniPathPlugin """
+    pytest_ini_path = None
+
+
+def get_pytest_ini_path():
+
+    pytest.main("--collect-only", plugins=[CollectIniPathPlugin()])
+    return(CollectorIniPath.pytest_ini_path)

--- a/pytest_watch/ini_config_helpers.py
+++ b/pytest_watch/ini_config_helpers.py
@@ -1,0 +1,35 @@
+import pytest
+
+# For collecting path of the ini
+
+
+class CollectIniPathPlugin(object):
+
+    def pytest_cmdline_main(self, config):
+        CollectorIniPath.pytest_ini_path = config.inifile.realpath().strpath
+
+
+class CollectorIniPath(object):
+
+    """ Object for storing the path from CollectIniPathPlugin """
+    pytest_ini_path = None
+
+
+def get_pytest_ini_path():
+
+    pytest.main("--collect-only", plugins=[CollectIniPathPlugin()])
+    return(CollectorIniPath.pytest_ini_path)
+
+
+def get_ini_option(config_parser, option_name):
+    if config_parser.has_option("pytest-watch", option_name):
+        return config_parser.get("pytest-watch", option_name)
+    else:
+        return None
+
+
+def get_ini_option_boolean(config_parser, option_name):
+    if config_parser.has_option("pytest-watch", option_name):
+        return config_parser.getboolean("pytest-watch", option_name)
+    else:
+        return False


### PR DESCRIPTION
Things Added:
1. CollectIniPathPlugin which acts as a pytest plugin and does a dry-run of pytest to capture the ini path in CollectorIniPath.pytest_ini_path class variable
2. Load "pytest-watch" section from that ini and read the options
3. Mix that option with cmdline args, giving preference to cmdline values

Todo:
1. Add proper tests for ini args loading
2. <strike> Refactor string and boolean variable loading code to diff. func, whole thing looks bad now </strike>