### PR TITLE
Add --onstart to docopt options and run it at first

### DIFF
--- a/pytest_watch/command.py
+++ b/pytest_watch/command.py
@@ -18,6 +18,7 @@ Options:
   --beforerun=<cmd> Run arbitrary command before tests are run.
   --onpass=<cmd>    Run arbitrary command on pass.
   --onfail=<cmd>    Run arbitrary command on failure.
+  --onstart=<cmd>    Run arbitrary command when starting.
   --onexit=<cmd>    Run arbitrary command when exiting.
   --runner=<cmd>    Run a custom command instead of py.test.
   --nobeep          Do not beep on failure.
@@ -68,6 +69,7 @@ def main(argv=None):
                  onfail=args['--onfail'],
                  runner=args['--runner'],
                  beforerun=args['--beforerun'],
+                 onstart=args['--onstart'],
                  onexit=args['--onexit'],
                  poll=args['--poll'],
                  extensions=extensions,

--- a/pytest_watch/watcher.py
+++ b/pytest_watch/watcher.py
@@ -124,9 +124,9 @@ class ChangeHandler(FileSystemEventHandler):
 
 
 def watch(directories=[], ignore=[], auto_clear=False, beep_on_failure=True,
-          onpass=None, onfail=None, runner=None, beforerun=None, onexit=None,
-          poll=False, extensions=[], args=[], spool=True, verbose=False,
-          quiet=False):
+          onpass=None, onfail=None, runner=None, beforerun=None, onstart=None,
+          onexit=None, poll=False, extensions=[], args=[], spool=True,
+          verbose=False, quiet=False):
     if not directories:
         directories = ['.']
     directories = [os.path.abspath(directory) for directory in directories]
@@ -155,6 +155,8 @@ def watch(directories=[], ignore=[], auto_clear=False, beep_on_failure=True,
         observer.schedule(event_handler, path=directory, recursive=False)
 
     # Watch and run tests until interrupted by user
+    if onstart:
+        os.system(onstart)
     try:
         observer.start()
         while True:

--- a/pytest_watch/watcher.py
+++ b/pytest_watch/watcher.py
@@ -145,6 +145,9 @@ def watch(directories=[], ignore=[], auto_clear=False, beep_on_failure=True,
     event_handler = ChangeHandler(
         auto_clear, beep_on_failure, onpass, onfail, runner, beforerun,
         extensions, args, spool, verbose, quiet)
+
+    if onstart:
+        os.system(onstart)
     event_handler.run()
 
     # Setup watchdog
@@ -155,8 +158,6 @@ def watch(directories=[], ignore=[], auto_clear=False, beep_on_failure=True,
         observer.schedule(event_handler, path=directory, recursive=False)
 
     # Watch and run tests until interrupted by user
-    if onstart:
-        os.system(onstart)
     try:
         observer.start()
         while True:


### PR DESCRIPTION
Changes made:

1. Add `--onstart` to docopt style docs
2. Pass it to watch and run before test-running loop

Fixes #32 