### PR TITLE
Fixed missing config.inifile attribute issue

### DIFF
--- a/pytest_watch/config.py
+++ b/pytest_watch/config.py
@@ -23,7 +23,7 @@ class CollectConfig(object):
         self.path = None
 
     def pytest_cmdline_main(self, config):
-        if config.inifile:
+        if getattr(config, 'inifile', None):
             self.path = str(config.inifile)
 
 


### PR DESCRIPTION
Seems inifile attribute was not always there.

Used with pytest 2.6.4 in another project resulted to fail at changed line.