### PR TITLE
Handle SystemExit also when calling _run_pytest_collect

### DIFF
--- a/pytest_watch/config.py
+++ b/pytest_watch/config.py
@@ -68,11 +68,11 @@ def _collect_config(pytest_args, silent=True):
                 return _run_pytest_collect(pytest_args)
         except KeyboardInterrupt:
             raise
-        except Exception:
+        except (Exception, SystemExit):
             pass
         # Print message and run again without silencing
-        print('Error: Could not run --collect-only to find the pytest config '
-              'file. Trying again without silencing stdout...',
+        print('Error: Could not run --collect-only to handle the pytest config '
+              'file. Trying again without silencing output...',
               file=sys.stderr)
 
     return _run_pytest_collect(pytest_args)


### PR DESCRIPTION
This might happen for e.g. `ptw -- --vv`, where `--vv` is an invalid
option for `py.test`.

```
[0]   …/pyenv/project/bin/ptw(9)<module>()
-> load_entry_point('pytest-watch', 'console_scripts', 'ptw')()
[1]   …/pytest-watch/pytest_watch/command.py(85)main()
-> if not merge_config(args, pytest_args, verbose=args['--verbose']):
[2]   …/pytest-watch/pytest_watch/config.py(86)merge_config()
-> config_path = _collect_config(pytest_args, silent)
[3]   …/pytest-watch/pytest_watch/config.py(68)_collect_config()
-> return _run_pytest_collect(pytest_args)
[4]   …/pytest-watch/pytest_watch/config.py(52)_run_pytest_collect()
-> exit_code = pytest.main(argv, plugins=[collect_config_plugin])
…
[20]   …/pyenv/project/lib/python3.5/site-packages/_pytest/config.py(726)parse_args()
-> self.error('\n'.join(lines))
[21] > /usr/lib64/python3.5/argparse.py(2385)error()
-> self.exit(2, _('%(prog)s: error: %(message)s\n') % args)
[22]   /usr/lib64/python3.5/argparse.py(2372)exit()
-> _sys.exit(status)
```

Now it will look like this, which is still a bit confusing, since it
refers to `ptw` and not `py.test`:

> Error: Could not run --collect-only to find the pytest config file. Trying again without silencing stdout...
> usage: ptw [options] [file_or_dir] [file_or_dir] [...]
> ptw: error: unrecognized arguments: --vv
>   inifile: …/project/setup.cfg
>   rootdir: …/project/project