### PR TITLE
Use the same interpreter when ptw is called outside of a virtual env

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -12,5 +12,6 @@ along with the following contributors:
 - Colton J. Provias ([@ColtonProvias](https://github.com/ColtonProvias))
 - Abhas Bhattacharya ([@bendtherules](https://github.com/bendtherules))
 - Lukasz Balcerzak ([@lukaszb](https://github.com/lukaszb))
+- Jace Browning ([@jacebrowning](https://github.com/jacebrowning))
 
 [home]: README.md

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 pytest-watch Changelog
 ======================
 
+- Enhancement: Use the same Python interpreter for `py.text` when `ptw` is run outside of an activated virtual environment.
 
 Version 4.1.0 (2016-04-08)
 --------------------------

--- a/pytest_watch/watcher.py
+++ b/pytest_watch/watcher.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 import os
+import sys
 import subprocess
 import time
 from traceback import format_exc
@@ -75,6 +76,14 @@ class EventListener(FileSystemEventHandler):
                 return
 
         self.event_queue.put((type(event), src_path, dest_path))
+
+
+def _get_pytest_runner(custom):
+    if custom:
+        return custom.split(' ')
+    if os.getenv('VIRTUAL_ENV'):
+        return ('py.test',)
+    return (sys.executable, '-m', 'pytest')
 
 
 def _reduce_events(events):
@@ -179,7 +188,7 @@ def watch(directories=[], ignore=[], extensions=[],  beep_on_failure=True,
           auto_clear=False, wait=False, beforerun=None, afterrun=None,
           onpass=None, onfail=None, onexit=None, runner=None, spool=None,
           poll=False, verbose=False, quiet=False, pytest_args=[]):
-    argv = (runner or 'py.test').split(' ') + (pytest_args or [])
+    argv = _get_pytest_runner(runner) + (pytest_args or [])
 
     if not directories:
         directories = ['.']


### PR DESCRIPTION
My primary use case here is `pipenv`. I would like to be able to do:

```
$ pipenv run ptw
```

But this attempts to find a globally installed pytest:

> Running: py.test
> Error: [Errno 2] No such file or directory: 'py.test'

With this change, pytest-watch will call pytest as a module if not currently running in an activated virtual environment. This should also make running pytest-watch globally a nicer experience by ensuring the same Python interpreter is used to run both `ptw` and `py.test` even if the user's shell is misconfigured.