### PR TITLE
Add watch single file feature

### DIFF
--- a/pytest_watch/command.py
+++ b/pytest_watch/command.py
@@ -106,7 +106,7 @@ def main(argv=None):
             return 2
 
     # Run pytest and watch for changes
-    return watch(directories=directories,
+    return watch(entries=directories,
                  ignore=args['--ignore'],
                  extensions=extensions,
                  beep_on_failure=not args['--nobeep'],


### PR DESCRIPTION
Maybe the documentation (i.e. https://github.com/joeyespo/pytest-watch/blob/ff2740e0ad5fb3018423c7440d13cb91f5045ae2/pytest_watch/command.py#L8) should also be changed to reflect the fact not only directories can be watched...