### PR TITLE
setup.py: Add PyPI trove classifiers for Python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,17 @@ setup(
     platforms='any',
     packages=find_packages(),
     install_requires=read('requirements.txt').splitlines(),
+    classifiers=[
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Topic :: Software Development :: Testing',
+    ],
     entry_points={
         'console_scripts': [
             'pytest-watch = pytest_watch:main',


### PR DESCRIPTION
This PR will change https://pypi.org/project/pytest-watch to show which versions of Python are supported.  Other tools like https://github.com/brettcannon/caniusepython3 also rely on these [trove classifiers](https://pypi.org/pypi?%3Aaction=list_classifiers).