### PR TITLE
Added re pattern to exclude based on the basename of a file

### DIFF
--- a/pytest_watch/command.py
+++ b/pytest_watch/command.py
@@ -30,7 +30,9 @@ Options:
                         This also enables --wait to prevent pdb interruption.
   --spool <delay>       Re-run after a delay (in milliseconds), allowing for
                         more file system events to queue up (default: 200 ms).
+  --pattern <str>       Regular expression for excluding based on basename
   -p --poll             Use polling instead of OS events (useful in VMs).
+  -e --emacs            Ignore emacs lockfiles; same as --pattern '^.#\S+$'
   -v --verbose          Increase verbosity of the output.
   -q --quiet            Decrease verbosity of the output (precedence over -v).
   -V --version          Print version and exit.
@@ -96,6 +98,15 @@ def main(argv=None):
     else:
         extensions = None
 
+    # Emacs flag
+    if args['--emacs']:
+        pattern = r'^\.#\S+$'
+    else:
+        pattern = None
+
+    if args['--pattern'] is not None:
+        pattern = args['--pattern']
+
     # Parse numeric arguments
     spool = args['--spool']
     if spool is not None:
@@ -109,6 +120,7 @@ def main(argv=None):
     return watch(entries=directories,
                  ignore=args['--ignore'],
                  extensions=extensions,
+                 pattern=pattern,
                  beep_on_failure=not args['--nobeep'],
                  auto_clear=args['--clear'],
                  wait=args['--wait'] or '--pdb' in pytest_args,

--- a/pytest_watch/watcher.py
+++ b/pytest_watch/watcher.py
@@ -4,6 +4,8 @@ import os
 import sys
 import subprocess
 import time
+import re
+
 from traceback import format_exc
 
 try:
@@ -77,10 +79,11 @@ class EventListener(FileSystemEventHandler):
     """
     Listens for changes to files and re-runs tests after each change.
     """
-    def __init__(self, extensions=[], event_queue=None):
+    def __init__(self, extensions=[], event_queue=None, pattern=None):
         super(EventListener, self).__init__()
         self.event_queue = event_queue or Queue()
         self.extensions = extensions or DEFAULT_EXTENSIONS
+        self.pattern = pattern
 
     def on_any_event(self, event):
         """
@@ -96,10 +99,20 @@ class EventListener(FileSystemEventHandler):
         if isinstance(event, FileMovedEvent):
             dest_path = os.path.relpath(event.dest_path)
 
+
+
         # Filter files that don't match the allowed extensions
         if not event.is_directory and self.extensions != ALL_EXTENSIONS:
             src_ext = os.path.splitext(src_path)[1].lower()
             src_included = src_ext in self.extensions
+
+            if src_included and self.pattern:
+                base = os.path.splitext( os.path.split(src_path)[1])[0]
+                p = re.compile( self.pattern)
+                if p.match( base):
+                    print( 'Excluding change to:', src_path)
+                    src_included = False
+
             dest_included = False
             if dest_path:
                 dest_ext = os.path.splitext(dest_path)[1].lower()
@@ -216,7 +229,7 @@ def run_hook(cmd, *args):
         subprocess.call(command, shell=True)
 
 
-def watch(entries=[], ignore=[], extensions=[], beep_on_failure=True,
+def watch(entries=[], ignore=[], extensions=[], pattern=None, beep_on_failure=True,
           auto_clear=False, wait=False, beforerun=None, afterrun=None,
           onpass=None, onfail=None, onexit=None, runner=None, spool=None,
           poll=False, verbose=False, quiet=False, pytest_args=[]):
@@ -237,7 +250,7 @@ def watch(entries=[], ignore=[], extensions=[], beep_on_failure=True,
             raise ValueError('Directory not found: ' + entry)
 
     # Setup event handler
-    event_listener = EventListener(extensions)
+    event_listener = EventListener(extensions,pattern=pattern)
 
     # Setup watchdog
     observer = PollingObserver() if poll else Observer()


### PR DESCRIPTION
This addresses issue #68

I added a command line argument `--pattern <re>`. If used, then source events on files with a base name that matches the regular expression specified by the argument with not trigger an update.

My primary use case is to avoid the false triggering caused by the lock file used by emacs.
The pattern to exclude these files is: `^\.#\S+$`
I added another command line argument (`-e` or `--emacs`) to do this directly. 