### PR TITLE
Add support for 'testpaths' and 'watchpaths' options in the ini file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Configuration
 -------------
 
 CLI options can be added to a `[pytest-watch]` section in your
-[pytest.ini file][pytest.ini] to persist them in your project. For example:
+*pytest.ini* or *setup.cfg* file to persist them in your project. For example:
 
 ```ini
 # pytest.ini
@@ -153,6 +153,23 @@ ignore = ./integration-tests
 nobeep = True
 ```
 
+The `[pytest-watch]` section may additionally provide the `testpaths` and/or
+the `watchpaths` options. These options are only considered when no directories
+were provided in the command. When both `testpaths` and `watchpaths` are
+provided then the former are provided to pytest while the latter are watched.
+When only the `testpaths` are provided then these are both watched and passed
+to pytest. When only the `watchpaths` are provided then these paths are
+watched but not passed to pytest, allowing it to pick up the `testpaths`
+provided in the `[pytest]` section. For example:
+
+```ini
+[pytest]
+addopts = --maxfail=2
+testpaths = ./tests
+
+[pytest-watch]
+watchpaths = ./lib ./tests
+```
 
 Alternatives
 ------------

--- a/pytest_watch/__init__.py
+++ b/pytest_watch/__init__.py
@@ -8,7 +8,7 @@ Local continuous test runner with pytest and watchdog.
 :license: MIT, see LICENSE for more details.
 """
 
-__version__ = '4.3.0-fork'
+__version__ = '2021.01.29'
 
 
 from .command import main, doc, version

--- a/pytest_watch/__init__.py
+++ b/pytest_watch/__init__.py
@@ -8,7 +8,7 @@ Local continuous test runner with pytest and watchdog.
 :license: MIT, see LICENSE for more details.
 """
 
-__version__ = '4.2.0'
+__version__ = '4.3.0-fork'
 
 
 from .command import main, doc, version

--- a/pytest_watch/config.py
+++ b/pytest_watch/config.py
@@ -110,7 +110,10 @@ def merge_config(args, pytest_args, silent=True, verbose=False):
             continue
 
         # Merge config option using the expected type
-        if isinstance(args[cli_name], list):
+        if cli_name == '--testpaths' or cli_name == '--watchpaths':
+            paths = config.get('pytest-watch', config_name).split()
+            args[cli_name].extend(paths)
+        elif isinstance(args[cli_name], list):
             args[cli_name].append(config.get('pytest-watch', config_name))
         elif isinstance(args[cli_name], bool):
             args[cli_name] = config.getboolean('pytest-watch', config_name)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(filename):
 
 setup(
     name='pytest-watch',
-    version='4.2.0',
+    version='4.3.0-fork',
     description='Local continuous test runner with pytest and watchdog.',
     long_description=read('README.rst'),
     author='Joe Esposito',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(filename):
 
 setup(
     name='pytest-watch',
-    version='4.3.0-fork',
+    version='2021.01.29',
     description='Local continuous test runner with pytest and watchdog.',
     long_description=read('README.rst'),
     author='Joe Esposito',


### PR DESCRIPTION
These options are only considered when no directories were provided in the command. When both `testpaths` and `watchpaths` are provided then the former are provided to pytest while the latter are watched. When only the `testpaths` are provided then these are both watched and passed to pytest. When only the `watchpaths` are provided then these paths are watched but not passed to pytest, allowing it to pick up the `testpaths` provided in the `[pytest]` section.