### PR TITLE
Fix toml config

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,23 @@ addopts = --maxfail=2
 [pytest-watch]
 ignore = ./integration-tests
 nobeep = True
+ext = .py,.txt
 ```
 
+CLI options can also be added to a `[tool.pytest-watch]` section in your
+[pyproject.toml file](https://pytest.org/en/stable/customize.html#pyproject-toml):
+
+```toml
+# pyproject.toml
+
+[tool.pytest.ini_options]
+addopts = "-ra -q"
+
+[tool.pytest-watch]
+ignore = "./integration-tests"
+nobeep = true
+ext = [ ".py", ".txt" ]
+```
 
 Alternatives
 ------------

--- a/README.rst
+++ b/README.rst
@@ -153,6 +153,23 @@ persist them in your project. For example:
    [pytest-watch]
    ignore = ./integration-tests
    nobeep = True
+   ext = .py,.txt
+
+CLI options can also be added to a ``[tool.pytest-watch]`` section in
+your `pyproject.toml
+file <https://pytest.org/en/stable/customize.html#pyproject-toml>`__:
+
+.. code:: toml
+
+   # pyproject.toml
+
+   [tool.pytest.ini_options]
+   addopts = "-ra -q"
+
+   [tool.pytest-watch]
+   ignore = "./integration-tests"
+   nobeep = true
+   ext = [ ".py", ".txt" ]
 
 Alternatives
 ------------


### PR DESCRIPTION
This pull request adds pyproject.toml support to pytest-watch.  It should also fix issue #114.  Currently pytest-watch fails if pytest is configured using the pyproject.toml file.  I also added to the readme's ini configuration example.  I thought it would be nice to show how to configure a list style arg.

https://pytest.org/en/stable/customize.html#pyproject-toml