### PR TITLE
Fix for pytest 7

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -18,5 +18,6 @@ along with the following contributors:
 - Emmanuel Leblond ([@touilleMan](https://github.com/touilleMan))
 - Alex Ford ([@asford](https://github.com/asford))
 - And Past ([@apast](https://github.com/apast))
+- Hugo van Kemenade ([@hugovk](https://github.com/hugovk))
 
 [home]: README.md

--- a/pytest_watch/config.py
+++ b/pytest_watch/config.py
@@ -33,8 +33,11 @@ class CollectConfig(object):
         self.path = None
 
     def pytest_cmdline_main(self, config):
-        if hasattr(config, 'inifile'):
-            # pytest >= 2.7.0
+        if hasattr(config, 'inipath'):
+            # pytest >= 7
+            inifile = config.inipath
+        elif hasattr(config, 'inifile'):
+            # pytest 2.7.0 - 6
             inifile = config.inifile
         else:
             # pytest < 2.7.0


### PR DESCRIPTION
Fixes #122.


`config.inifile` was deprecated so for pytest 7 check whether the new `config.inipath` is available first.

It's a `pathlib.Path` rather than a `py.path.local`, but we're calling `str` on it so that's fine.


```console
$ ptw test_it.py

[Wed Dec  8 11:59:07 2021] Running: /Library/Frameworks/Python.framework/Versions/3.10/bin/python3 -m pytest test_it.py
========================================================== test session starts ===========================================================
platform darwin -- Python 3.10.1, pytest-7.0.0rc1, pluggy-1.0.0
rootdir: /Users/hugo/github/test
plugins: respx-0.19.0, freezegun-0.4.2, hypothesis-6.28.0, flaky-3.7.0, xdist-2.4.0, timeout-2.0.1, anyio-3.3.4, forked-1.3.0, cov-3.0.0
collected 1 item

test_it.py .                                                                                                                       [100%]

=========================================================== 1 passed in 0.06s ============================================================
```