### PR TITLE
Update version of `watchdog` library

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -18,5 +18,6 @@ along with the following contributors:
 - Emmanuel Leblond ([@touilleMan](https://github.com/touilleMan))
 - Alex Ford ([@asford](https://github.com/asford))
 - And Past ([@apast](https://github.com/apast))
+- Sohang Chopra ([@sohang3112](https://github.com/sohang3112))
 
 [home]: README.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 docopt>=0.4.0
 colorama>=0.3.3
-watchdog>=0.6.0
+watchdog>=2.1.9
 pytest>=2.6.4


### PR DESCRIPTION
Previously, old version of `watchdog` library was being used, which is not compatible with Python 3.3+. I have modified `watchdog` version to latest in `requirements.txt`. **This fixes [Issue 127](https://github.com/joeyespo/pytest-watch/issues/127).**