### PR TITLE
Fix for setuptools change for description-file.

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -18,5 +18,6 @@ along with the following contributors:
 - Emmanuel Leblond ([@touilleMan](https://github.com/touilleMan))
 - Alex Ford ([@asford](https://github.com/asford))
 - And Past ([@apast](https://github.com/apast))
+- Matthew Klein ([@johnny-5-code](https://github.com/johnny-5-code))
 
 [home]: README.md

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.rst
+description_file = README.rst

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(filename):
 
 setup(
     name='pytest-watch',
-    version='4.2.0',
+    version='4.2.1',
     description='Local continuous test runner with pytest and watchdog.',
     long_description=read('README.rst'),
     author='Joe Esposito',


### PR DESCRIPTION
New setuptools versions no longer support `description-file`.  It needs to be `description_file`

Example error when trying to install:
```
      setuptools.errors.InvalidConfigError: Invalid dash-separated key 'description-file' in 'metadata' (setup.cfg), please use the underscore name
      'description_file' instead.
```